### PR TITLE
Sanitize generated backend tfstate of private access keys after creating/updating backend storage resource

### DIFF
--- a/inputs.tf
+++ b/inputs.tf
@@ -39,3 +39,9 @@ variable "tenant_id" {
   description = "The tenant ID to use for the Terraform state"
   default     = null
 }
+
+variable "remove_secrets_from_state" {
+  type = bool
+  description = "Whether to sanitize tfstate of access keys automatically created on created resources. Keys remain untouched on created assets."
+  default = true
+}

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,8 @@ resource "terraform_data" "always_run" {
 
 resource "null_resource" "sanitize_state" {
 
+  count = var.remove_secrets_from_state ? 1 : 0
+
   provisioner "local-exec" {
     command = <<EOT
       # Check if jq is installed


### PR DESCRIPTION
## Description

The terraform Azure storage provider adds [primary_access_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account.html#primary_access_key-1) (and other secure attributes) to the state file, and this feature adds locally executed `jq` to rewrite the generated `terraform.tfstate` file without these private access keys.

**Note:** I am not certain how to "bump" the version, so I simply tagged this commit as `v0.1.2` as per the pattern.

## Tested

I began with a `terraform destroy` & `terraform init` to completely clean the slate. Without the `jq` commands, secure keys were present in generated `terraform.tfstate` (and subsequently `terraform.tfstate.backup` on re-applies). With the `jq` the secure keys were no longer present. (In fact if the file is open in your editor, for a brief moment, you can see that they are written, and then you see them disappear when the file is overwritten with the sanitized state json)

## Notes

I had trouble getting the new sanitization script to rerun without tricks, so I included an additional trick:
```
resource "terraform_data" "always_run" {
  input = timestamp()
}

...

resource "null_resource" "sanitize_state" {
  ...

  lifecycle {
    replace_triggered_by = [ terraform_data.always_run ]
  }

  ...
}
```
