### PR TITLE
Sets Azure Storage authentication method from Access Key to Entra User Account

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 This is a terraform module for initializing a terraform state backend in Azure. 
 
 By default, it creates a resource group named `terraform-state`, a storage account with a unique name, and a container named "terraform-state", 
+
+Azure will not auto-assign sufficient access privilege to your az cli user running terraform automatically. Follow this environment backend module's apply with authenticated:
+```
+az role assignment create --assignee PRINCIPAL_ID --role "Storage Blob Data Contributor" --scope $(terraform output -raw storage_role_access_scope -state=PATH_TO_TFSTATE)
+```
+While the az role assignment is very quick, it may take up to ten minutes for your principal to gain role access to this resource (see [learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access](https://learn.microsoft.com/en-us/azure/storage/blobs/assign-azure-role-data-access?tabs=azure-cli#:~:text=When%20you%20assign%20roles%20or%20remove%20role%20assignments%2C%20it%20can%20take%20up%20to%2010%20minutes%20for%20changes%20to%20take%20effect.)).
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,10 @@ resource "azurerm_storage_account" "tfstate" {
 
   shared_access_key_enabled = false
 
+  identity {
+    type = "SystemAssigned"
+  }
+
   lifecycle {
     ignore_changes = [
       tags,
@@ -59,6 +63,12 @@ resource "azurerm_storage_container" "tfstate" {
   name                  = var.container_name
   storage_account_name  = azurerm_storage_account.tfstate.name
   container_access_type = "private"
+}
+
+resource "azurerm_role_assignment" "tfstate_access" {
+  principal_id   = "916c9e0d-a57f-47a1-8c07-a75b1f2d621d"  # Entra ID Object ID for the user or group
+  role_definition_name = "Storage Blob Data Contributor"  # Allows read/write access to blobs
+  scope          = "${azurerm_storage_account.tfstate.id}/blobServices/default/containers/tfstate"
 }
 
 resource "terraform_data" "always_run" {


### PR DESCRIPTION
## Description

Since we don't want to access Azure Storage for terraform backend storage via Access Keys, I had to do a little dance to enable Entra User Authentication.
* I don't know if this is the right approach to solve the issue
* It's also **WIP**, because I have temporarily set the new role `principal_id` to a group that my az-cli user is a member of for convenience, but either we need a more appropriate group or some other approach.

Another idea is to create and apply a Managed Identity. Would this work for "anyone running the parent terraform" (who ultimately needs access to read tfstate stored in the container).

**Update:** Each of the commits on this PR is another slightly different stab and none better than the previous. I fail to end up with an idempotent (can rerun `apply` and either first-time create or detect no differences) outcome: I always get either duplicate resources:
<img width="1265" alt="image" src="https://github.com/user-attachments/assets/aadef6fa-ad25-4a03-9f20-ff5c81a528eb">
or failure:
<img width="574" alt="image" src="https://github.com/user-attachments/assets/62efb411-d4a6-48e8-b7ed-a8eb73f54d2b">
or failure:
![image](https://github.com/user-attachments/assets/a2379ab4-e116-4a26-b969-399ea7fe6976)

I am probably out of ideas. What I am going for is:
* Storing remote backend in Azure Storage
* That can be accessed by Entra User Access (without Access Keys)
* By a developer running the parent terraform script. I'd even settle from _just me_ running that parent terraform script.

