### PR TITLE
Adds tfstate role access scope as output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,6 @@ provider "azurerm" {
   storage_use_azuread = true
 }
 
-
 resource "random_string" "storage_account_name" {
   length  = 14
   special = false
@@ -26,6 +25,7 @@ resource "random_string" "storage_account_name" {
 
 locals {
   storage_account_name = var.storage_account_name == null ? "tfstate00${random_string.storage_account_name.result}" : var.storage_account_name
+  tfstate_role_access_scope = "${azurerm_storage_account.tfstate.id}/blobServices/default/containers/tfstate"
 }
 
 resource "azurerm_resource_group" "tfstate" {
@@ -108,4 +108,8 @@ output "storage_account_name" {
 
 output "container_name" {
   value = azurerm_storage_container.tfstate.name
+}
+
+output "tfstate_role_access_scope" {
+  value = local.tfstate_role_access_scope
 }


### PR DESCRIPTION
# Description

It is important that any runner (local user or github runner) have data access to the storage blob, even if it is the owner who just created it. This PR provides a simple scope known after creation to the blob storage. Other scopes may be desirable (like subscription, containing resource group, or storage container), so providing a single scope may not be as useful as providing the generated object or the object's ID reference. Either scopes or IDs, whatever helps the implementing developer.

Example implementation:
```
resource "azurerm_role_assignment" "github_oidc_blob_contributor" {
  scope                 = module.state_backend.tfstate_role_access_scope
  role_definition_name  = "Storage Blob Data Contributor"
  principal_id          = azuread_service_principal.github_oidc.object_id
}
```
