### PR TITLE
#12: Fixes error thrown when requesting to create a new resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ data "azurerm_client_config" "current" {
 
 
 resource "azurerm_resource_group" "tfstate" {
-  count =   var.create_resource_group == true ? 1 : 0
+  count =   var.create_resource_group ? 1 : 0
   name     = var.resource_group_name
   location = var.location
 
@@ -46,8 +46,8 @@ resource "azurerm_resource_group" "tfstate" {
 }
 
 data "azurerm_resource_group" "tfstate" {
-  count =   var.create_resource_group == true ? 1 : 0
-  name     = var.resource_group_name
+  count = var.create_resource_group ? 0 : 1
+  name  = var.resource_group_name
 }
 
 resource "azurerm_storage_account" "tfstate" {


### PR DESCRIPTION
# Description

Fixes error thrown when requesting to create a new resource
- boolean conditional assignment logic was backward in data resource count 0 or 1
- replaces explicit logic for truthy true/false implied

## How to test

Use source at `?ref=90519bfa77d856a5901e136606c727c847a7e740`

## How to confirm logic

The _same logic_ was tested out-of-band with a known subscription, with and without existing resource group, like:

```
terraform {
  required_version = ">= 0.13"
  required_providers {
    azurerm = {
      source  = "hashicorp/azurerm"
      version = "=4.26.0"
    }
  }
}

data "azurerm_client_config" "current" {}

provider "azurerm" {
  features {}
  subscription_id = "YOUR_SUBSCRIPTION_ID"
  storage_use_azuread = true
}

data "azurerm_resource_group" "pre_existing" {
  count =   var.create_resource_group ? 0 : 1
  name     = var.resource_group_name
}

resource "azurerm_resource_group" "to_create" {
  count =   var.create_resource_group ? 1 : 0
  name     = var.resource_group_name
  location = "southcentralus"
}

variable "create_resource_group" {
  type    = bool
  default = false
}

variable "resource_group_name" {
  type    = string
  default = "desired-new-resource-group-name"
}

output "resource_group_name" {
  value = var.create_resource_group ? azurerm_resource_group.to_create[0].name : data.azurerm_resource_group.pre_existing[0].name  
}
```

and called various ways like:
* toggle default value `create_resource_group` in code, call `terraform plan`
* call `terraform plan -var 'create_resource_group=true'` etc
* call `terraform plan -var 'create_resource_group=false' -var 'resource_group_name=ReviewEm-dev-Resource-Group'` etc.

Resolves #12 
