### PR TITLE
duplicate scope for blob storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,11 +80,12 @@ resource "azurerm_storage_container" "tfstate" {
   container_access_type = "private"
 }
 
-resource "azurerm_role_assignment" "tfstate_role_assignment" {
-  scope               = azurerm_storage_container.tfstate.id
-  role_definition_name  = "Storage Blob Data Owner"
-  principal_id        = data.azurerm_client_config.current.object_id
-}
+# -- commit out duplicate scope that is set by github_oidc
+# resource "azurerm_role_assignment" "tfstate_role_assignment" {
+#   scope               = azurerm_storage_container.tfstate.id
+#   role_definition_name  = "Storage Blob Data Owner"
+#   principal_id        = data.azurerm_client_config.current.object_id
+# }
 
 resource "terraform_data" "always_run" {
   input = timestamp()

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,7 +29,7 @@ output "container_name" {
   value = azurerm_storage_container.tfstate.name
 }
 
-output "container_role_access_scope" {
-  description = "Complete scope string down to the tfstate storage container"
-  value = azurerm_role_assignment.tfstate_role_assignment.scope
-}
+# output "container_role_access_scope" {
+#   description = "Complete scope string down to the tfstate storage container"
+#   value = azurerm_role_assignment.tfstate_role_assignment.scope
+# }


### PR DESCRIPTION
While chasing the 409 errors, discovered that the github_oidc repo is applying subscription scopes that are duplicate of the tfstate_role_assignment being applied to the container within the blob storage.  When the "it-ae-tfmod-azure-state module" goes to apply the tfstate_role_assignment to the blob storage directly, a 409 is generated because its a duplicate of the inherited role already applied at the subscription level.

I also found that additional 409's can be generated if the IAM has already had the permissions applied by previous versions of the repo.  I was using a much older version of this repo that had already applied some of the scopes/roles but because of module changes, the resources changed enough that the state didn't have the scope tracked, but because the scope already existed on the resource, a 409 was generated.  Once I manually removed all of the github_oidc scopes within the subscription and blob storage resources and ran the version 0.2.2 (state) and 0.1 (oidc).   Running a brand new deployment of IaC for the setup process, generated a single 409 error related to the blob storage container trying to apply a scope.  I committed out the sections in the PR and was able to run several plans and apply's without any further 409 errors.