### PR TITLE
Entra group support for blob owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ No modules.
 | <a name="input_tfstate_acl_default_action"></a> [tfstate\_acl\_default\_action](#input\_tfstate\_acl\_default\_action) | (Required) Specifies the default action of allow or deny when no other rules match. Valid options are Deny or Allow. | `string` | `"Deny"` | no |
 | <a name="input_tfstate_acl_enable"></a> [tfstate\_acl\_enable](#input\_tfstate\_acl\_enable) | Enables or Disabled the setup of an ACL for the blob storage account being created. | `bool` | `false` | no |
 | <a name="input_tfstate_acl_ip_rule"></a> [tfstate\_acl\_ip\_rule](#input\_tfstate\_acl\_ip\_rule) | (Optional) List of public IP or IP ranges in CIDR Format. Only IPv4 addresses are allowed. Private IP address ranges (as defined in RFC 1918) are not allowed. | `list(string)` | `null` | no |
+| <a name="input_tfstate_entra_group_blob_owner_list"></a> [tfstate\_entra\_group\_blob\_owner\_list](#input\_tfstate\_entra\_group\_blob\_owner\_list) | (Optional) List of Entra ID group object IDs to assign the Storage Blob Data Owner role on the storage account.  Used to provide more then just the authors access to the blob container created by this module. | `list(string)` | `[]` | no |
 
 ## Outputs
 
@@ -129,7 +130,7 @@ No modules.
 | <a name="output_backend_config"></a> [backend\_config](#output\_backend\_config) | Will contain a block of Terraform code that can be used to consume the created backend config. |
 | <a name="output_container_id"></a> [container\_id](#output\_container\_id) | Will output the tfstate storage container id |
 | <a name="output_container_name"></a> [container\_name](#output\_container\_name) | Will output the tfstate storage container name |
-| <a name="output_container_role_access_scope"></a> [container\_role\_access\_scope](#output\_container\_role\_access\_scope) | Complete scope string down to the tfstate storage container |
+| <a name="output_container_role_access_scope"></a> [container\_role\_access\_scope](#output\_container\_role\_access\_scope) | n/a |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | Will output the name of the resource group |
 | <a name="output_storage_account_id"></a> [storage\_account\_id](#output\_storage\_account\_id) | ID of the tfstate storage account suitable for very broad scope string building (see container\_role\_access\_scope) |
 | <a name="output_storage_account_name"></a> [storage\_account\_name](#output\_storage\_account\_name) | Will output the storage account name |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ No modules.
 | <a name="input_tfstate_acl_default_action"></a> [tfstate\_acl\_default\_action](#input\_tfstate\_acl\_default\_action) | (Required) Specifies the default action of allow or deny when no other rules match. Valid options are Deny or Allow. | `string` | `"Deny"` | no |
 | <a name="input_tfstate_acl_enable"></a> [tfstate\_acl\_enable](#input\_tfstate\_acl\_enable) | Enables or Disabled the setup of an ACL for the blob storage account being created. | `bool` | `false` | no |
 | <a name="input_tfstate_acl_ip_rule"></a> [tfstate\_acl\_ip\_rule](#input\_tfstate\_acl\_ip\_rule) | (Optional) List of public IP or IP ranges in CIDR Format. Only IPv4 addresses are allowed. Private IP address ranges (as defined in RFC 1918) are not allowed. | `list(string)` | `null` | no |
-| <a name="input_tfstate_entra_group_blob_owner_list"></a> [tfstate\_entra\_group\_blob\_owner\_list](#input\_tfstate\_entra\_group\_blob\_owner\_list) | (Optional) List of Entra ID group object IDs to assign the Storage Blob Data Owner role on the storage account.  Used to provide more then just the authors access to the blob container created by this module. | `list(string)` | `[]` | no |
+| <a name="input_tfstate_entra_group_blob_owner_list"></a> [tfstate\_entra\_group\_blob\_owner\_list](#input\_tfstate\_entra\_group\_blob\_owner\_list) | (Optional) List of Entra ID group object IDs to assign the Storage Blob Data Owner role on the storage account. | `list(string)` | `[]` | no |
 
 ## Outputs
 
@@ -130,7 +130,7 @@ No modules.
 | <a name="output_backend_config"></a> [backend\_config](#output\_backend\_config) | Will contain a block of Terraform code that can be used to consume the created backend config. |
 | <a name="output_container_id"></a> [container\_id](#output\_container\_id) | Will output the tfstate storage container id |
 | <a name="output_container_name"></a> [container\_name](#output\_container\_name) | Will output the tfstate storage container name |
-| <a name="output_container_role_access_scope"></a> [container\_role\_access\_scope](#output\_container\_role\_access\_scope) | n/a |
+| <a name="output_container_role_access_scope"></a> [container\_role\_access\_scope](#output\_container\_role\_access\_scope) | List of scope string(s) down to the tfstate storage container |
 | <a name="output_resource_group_name"></a> [resource\_group\_name](#output\_resource\_group\_name) | Will output the name of the resource group |
 | <a name="output_storage_account_id"></a> [storage\_account\_id](#output\_storage\_account\_id) | ID of the tfstate storage account suitable for very broad scope string building (see container\_role\_access\_scope) |
 | <a name="output_storage_account_name"></a> [storage\_account\_name](#output\_storage\_account\_name) | Will output the storage account name |

--- a/inputs.tf
+++ b/inputs.tf
@@ -81,3 +81,9 @@ variable "tfstate_acl_bypass" {
   description = " (Optional) Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of Logging, Metrics, AzureServices, or None. Defaults to [\"AzureServices\"]."
   default = null
 }
+
+variable "tfstate_entra_group_blob_owner_list" {
+  type = list(string)
+  description = "(Optional) List of Entra ID group object IDs to assign the Storage Blob Data Owner role on the storage account."
+  default = null
+}

--- a/inputs.tf
+++ b/inputs.tf
@@ -85,5 +85,5 @@ variable "tfstate_acl_bypass" {
 variable "tfstate_entra_group_blob_owner_list" {
   type = list(string)
   description = "(Optional) List of Entra ID group object IDs to assign the Storage Blob Data Owner role on the storage account."
-  default = null
+  default = []
 }

--- a/main.tf
+++ b/main.tf
@@ -25,14 +25,15 @@ resource "random_string" "storage_account_name" {
   upper   = false
 }
 
-locals {
-  storage_account_name = var.storage_account_name == null ? "tfstate00${random_string.storage_account_name.result}" : var.storage_account_name
-}
-
 data "azurerm_client_config" "current" {
 }
-
-
+locals {
+  storage_account_name = var.storage_account_name == null ? "tfstate00${random_string.storage_account_name.result}" : var.storage_account_name
+    blob_owner_object_ids = concat(
+    var.tfstate_entra_group_blob_owner_list != null ? var.tfstate_entra_group_blob_owner_list : [],
+    [data.azurerm_client_config.current.object_id]
+  )
+}
 resource "azurerm_resource_group" "tfstate" {
   count =   var.create_resource_group ? 1 : 0
   name     = var.resource_group_name
@@ -81,9 +82,10 @@ resource "azurerm_storage_container" "tfstate" {
 }
 
 resource "azurerm_role_assignment" "tfstate_role_assignment" {
-  scope               = azurerm_storage_container.tfstate.id
-  role_definition_name  = "Storage Blob Data Owner"
-  principal_id        = data.azurerm_client_config.current.object_id
+  for_each             = toset(local.blob_owner_object_ids)
+  scope                = azurerm_storage_container.tfstate.id
+  role_definition_name = "Storage Blob Data Owner"
+  principal_id         = each.value 
 }
 
 resource "azurerm_storage_account_network_rules" "tfstate_acl" {

--- a/main.tf
+++ b/main.tf
@@ -29,8 +29,8 @@ data "azurerm_client_config" "current" {
 }
 locals {
   storage_account_name = var.storage_account_name == null ? "tfstate00${random_string.storage_account_name.result}" : var.storage_account_name
-    blob_owner_object_ids = concat(
-    var.tfstate_entra_group_blob_owner_list != null ? var.tfstate_entra_group_blob_owner_list : [],
+  blob_owner_object_ids = concat(
+    var.tfstate_entra_group_blob_owner_list,
     [data.azurerm_client_config.current.object_id]
   )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,4 +31,5 @@ output "container_name" {
 
 output "container_role_access_scope" {
   value = [for ra in azurerm_role_assignment.tfstate_role_assignment : ra.scope]
+  description = "List of scope string(s) down to the tfstate storage container"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,6 +30,5 @@ output "container_name" {
 }
 
 output "container_role_access_scope" {
-  description = "Complete scope string down to the tfstate storage container"
-  value = azurerm_role_assignment.tfstate_role_assignment.scope
+  value = [for ra in azurerm_role_assignment.tfstate_role_assignment : ra.scope]
 }


### PR DESCRIPTION
added support for using Entra Groups instead of only the logged in user to be added to the Blow Owner Role for the container being created.  Left previous logic in place so it will always capture the logged in user.

By using the data sources of the github_iam config, those groups are now able to be added to the Blow Owner Role of the container so that more than the author can manage the terraform locally.