### PR TITLE
[#20] Speculative implementation at padding storage account name with env name (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,16 @@ No modules.
 <!-- END_TF_DOCS -->
 
 These output values will serve as your terraform IaC project inputs.
+
+> [!IMPORTANT]
+> **Upgrading from version 0.2?** 
+> 
+> Version 0.3 includes breaking changes that require manual state migration. Resource naming conventions have changed, and new features have been added.
+> 
+> **📖 Please review the [UPDATE.md](UPDATE.md) guide before upgrading to ensure a smooth transition.**
+> 
+> Key changes include:
+> - Storage container naming logic updates
+> - Resource group data source logic fixes  
+> - New network ACL controls
+> - State sanitization method changes

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ output "storage_account_name" {
   value = module.state_backend.storage_account_name
 }
 output "backend_config" {
-  value = module.state_backend.backend
+  value = module.state_backend.backend_config
 }
 ```
 
@@ -102,25 +102,28 @@ No modules.
 | [random_string.storage_account_name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.tfstate](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_client_id"></a> [client\_id](#input\_client\_id) | The client ID to use for authenticating to Azure. Terraform authentication will overwrite this. | `string` | `null` | no |
-| <a name="input_container_name"></a> [container\_name](#input\_container\_name) | The name of the storage container to use for the Terraform state | `string` | `"terraform-state"` | no |
+| <a name="input_container_name"></a> [container\_name](#input\_container\_name) | The name of the storage container to use for the Terraform state | `string` | `null` | no |
 | <a name="input_create_resource_group"></a> [create\_resource\_group](#input\_create\_resource\_group) | Whether to create or to attach to an existing resource group. See `resource_group_name`. Defaults to true. | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment name to include for automatically named resources. | `string` | `null` | no |
 | <a name="input_location"></a> [location](#input\_location) | The location to use for the Terraform state | `string` | `"centralus"` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group to use for the Terraform state. If `create_resource_group` is true, this will be the name of the created resource group. If `create_resource_group` is false, this module will find the existing resource group by that name. | `string` | `"terraform-state"` | no |
 | <a name="input_resource_provider_registrations"></a> [resource\_provider\_registrations](#input\_resource\_provider\_registrations) | Set to 'none' if using a limited user without permission to do provider registrations | `string` | `null` | no |
 | <a name="input_sanitize_state_secrets"></a> [sanitize\_state\_secrets](#input\_sanitize\_state\_secrets) | Whether to sanitize access keys on created blob storage resources automatically stored in tfstate by azurerm provider. | `bool` | `true` | no |
 | <a name="input_storage_account_name"></a> [storage\_account\_name](#input\_storage\_account\_name) | The name of the storage account to use for the Terraform state. Leave blank to let Terraform manage a globally unique name to fit Azure constraints. | `string` | `null` | no |
-| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The subscription ID to use for the Terraform state | `string` | `null` | no |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | The subscription ID to use for the Terraform state | `string` | n/a | yes |
 | <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | The tenant ID to use for the Terraform state | `string` | `null` | no |
 | <a name="input_tfstate_acl_bypass"></a> [tfstate\_acl\_bypass](#input\_tfstate\_acl\_bypass) | (Optional) Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of Logging, Metrics, AzureServices, or None. Defaults to ["AzureServices"]. | `list(string)` | `null` | no |
 | <a name="input_tfstate_acl_default_action"></a> [tfstate\_acl\_default\_action](#input\_tfstate\_acl\_default\_action) | (Required) Specifies the default action of allow or deny when no other rules match. Valid options are Deny or Allow. | `string` | `"Deny"` | no |
 | <a name="input_tfstate_acl_enable"></a> [tfstate\_acl\_enable](#input\_tfstate\_acl\_enable) | Enables or Disabled the setup of an ACL for the blob storage account being created. | `bool` | `false` | no |
 | <a name="input_tfstate_acl_ip_rule"></a> [tfstate\_acl\_ip\_rule](#input\_tfstate\_acl\_ip\_rule) | (Optional) List of public IP or IP ranges in CIDR Format. Only IPv4 addresses are allowed. Private IP address ranges (as defined in RFC 1918) are not allowed. | `list(string)` | `null` | no |
+| <a name="input_tfstate_key"></a> [tfstate\_key](#input\_tfstate\_key) | The key to use for the Terraform state (ie. the blob name within the container) | `string` | `null` | no |
 
 ## Outputs
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -1,0 +1,150 @@
+# Upgrade Guide: Version 0.2 to 0.3
+
+This guide helps you upgrade from version 0.2 to 0.3 of the Azure Terraform State module. Several resource naming conventions and configurations have changed, requiring careful migration.
+
+## ⚠️ Important Notice
+
+**This upgrade requires manual intervention and state imports due to resource name changes. Plan for maintenance downtime.**
+
+## Key Changes
+
+### 1. Storage Container Name Change
+- **Old**: Used `var.container_name` directly
+- **New**: Uses `local.container_name` with environment-based naming
+
+### 2. Storage Account Name Logic Update
+- **Old**: Simple conditional logic
+- **New**: Enhanced naming with environment support and 24-character limit
+
+### 3. Data Source Logic Fix
+- **Old**: `data.azurerm_resource_group.tfstate` count was incorrectly set to 1 when `create_resource_group = true`
+- **New**: Properly inverted logic - count is 0 when creating RG, 1 when using existing
+
+### 4. New Resources Added
+- `azurerm_storage_account_network_rules.tfstate_acl` - Network access controls
+- `data.azurerm_subscription.current` - Subscription data source
+
+### 5. State Sanitization Changes
+- **Old**: Used `terraform_data.always_run` trigger and jq-based state sanitization
+- **New**: Uses `null_resource.sanitize_state` with Azure CLI key renewal
+- **Variable**: `var.remove_secrets_from_state` → `var.sanitize_state_secrets`
+
+## Pre-Upgrade Steps
+
+1. **Backup your current Terraform state**:
+   ```bash
+   terraform state pull > backup-state-v0.2.json
+   ```
+
+2. **Document current resource names**:
+   ```bash
+   # Note your current container name
+   terraform show | grep container_name
+   
+   # Note your current storage account name  
+   terraform show | grep storage_account_name
+   ```
+
+## Upgrade Process
+
+### Step 1: Update Module Version
+Update your module reference to use version 0.3+.
+
+### Step 2: Handle Container Name Change
+
+If your container name will change due to the new naming logic:
+
+```bash
+# Remove the old container from state
+terraform state rm module.azure_state.azurerm_storage_container.tfstate
+
+# Import the container with new naming
+terraform import module.azure_state.azurerm_storage_container.tfstate /subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Storage/storageAccounts/{storage-account}/blobServices/default/containers/{NEW-container-name}
+```
+
+### Step 3: Handle Resource Group Data Source
+
+```bash
+# If you're using an existing resource group (create_resource_group = false)
+# Remove the incorrectly counted data source
+terraform state rm module.azure_state.data.azurerm_resource_group.tfstate
+
+# The data source will be recreated automatically on next plan/apply
+```
+
+### Step 4: Remove Old Resources
+
+```bash
+# Remove the old terraform_data resource if it exists
+terraform state rm module.azure_state.terraform_data.always_run
+```
+
+### Step 5: Plan and Apply
+
+```bash
+# Review changes
+terraform plan
+
+# Apply the changes
+terraform apply
+```
+
+## Variable Updates Required
+
+Update your variable definitions:
+
+```hcl
+# Old variable (remove)
+# remove_secrets_from_state = true
+
+# New variable (add)
+sanitize_state_secrets = true
+
+# New ACL variables (optional)
+tfstate_acl_enable = false
+tfstate_acl_default_action = "Allow"
+tfstate_acl_ip_rule = []
+tfstate_acl_bypass = ["AzureServices"]
+```
+
+## Post-Upgrade Verification
+
+1. **Verify backend configuration**:
+   ```bash
+   terraform output backend_config
+   ```
+
+2. **Test state access**:
+   ```bash
+   terraform plan
+   ```
+
+3. **Verify container access**:
+   - Check that your service principal can still access the state container
+   - Verify network rules if ACL is enabled
+
+## Rollback Plan
+
+If issues occur:
+
+1. **Restore state backup**:
+   ```bash
+   terraform state push backup-state-v0.2.json
+   ```
+
+2. **Revert module version** in your configuration
+
+3. **Re-run terraform apply**
+
+## Support
+
+- Review the module's `variables.tf` for new variable options
+- Check the `outputs.tf` for updated output values
+- Test in a non-production environment first
+
+---
+
+**Need help?** Create an issue in the module repository with:
+- Your current configuration
+- Error messages encountered
+- Steps already attempted

--- a/inputs.tf
+++ b/inputs.tf
@@ -25,7 +25,13 @@ variable "location" {
 variable "container_name" {
   type        = string
   description = "The name of the storage container to use for the Terraform state"
-  default     = "terraform-state"
+  default     = null
+}
+
+variable "tfstate_key" {
+  type        = string
+  description = "The key to use for the Terraform state (ie. the blob name within the container)"
+  default     = null
 }
 
 variable "client_id" {
@@ -37,7 +43,6 @@ variable "client_id" {
 variable "subscription_id" {
   type        = string
   description = "The subscription ID to use for the Terraform state"
-  default     = null
 }
 
 variable "tenant_id" {

--- a/inputs.tf
+++ b/inputs.tf
@@ -1,3 +1,9 @@
+variable "environment" {
+  type        = string
+  description = "The environment name to include for automatically named resources."
+  default     = null
+}
+
 variable "storage_account_name" {
   type        = string
   description = "The name of the storage account to use for the Terraform state. Leave blank to let Terraform manage a globally unique name to fit Azure constraints."

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,10 @@ resource "random_string" "storage_account_name" {
 }
 
 locals {
-  storage_account_name = var.storage_account_name == null ? "tfstate00${random_string.storage_account_name.result}" : var.storage_account_name
+  environment_str = var.environment != null ? lower(var.environment) : ""
+  storage_account_name = var.storage_account_name != null ? var.storage_account_name : (
+    substr("tfst${local.environment_str}${random_string.storage_account_name.result}", 0, 24)
+  )
 }
 
 data "azurerm_client_config" "current" {
@@ -34,7 +37,7 @@ data "azurerm_client_config" "current" {
 
 
 resource "azurerm_resource_group" "tfstate" {
-  count =   var.create_resource_group ? 1 : 0
+  count    = var.create_resource_group ? 1 : 0
   name     = var.resource_group_name
   location = var.location
 
@@ -51,16 +54,16 @@ data "azurerm_resource_group" "tfstate" {
 }
 
 resource "azurerm_storage_account" "tfstate" {
-  name                     = local.storage_account_name
+  name = local.storage_account_name
 
   # --- Conditional Attributes ---
   # If create_resource_group is true, use the name from the created resource (at index 0).
   # Otherwise, use the name from the data source (at index 0).
-  resource_group_name    = var.create_resource_group ? azurerm_resource_group.tfstate[0].name : data.azurerm_resource_group.tfstate[0].name
+  resource_group_name = var.create_resource_group ? azurerm_resource_group.tfstate[0].name : data.azurerm_resource_group.tfstate[0].name
 
   # If create_resource_group is true, use the location from the created resource (at index 0).
   # Otherwise, use the location from the data source (at index 0).
-  location               = var.create_resource_group ? azurerm_resource_group.tfstate[0].location : data.azurerm_resource_group.tfstate[0].location
+  location = var.create_resource_group ? azurerm_resource_group.tfstate[0].location : data.azurerm_resource_group.tfstate[0].location
   # --- End Conditional Attributes ---
   account_tier             = "Standard"
   account_replication_type = "GRS"
@@ -81,20 +84,20 @@ resource "azurerm_storage_container" "tfstate" {
 }
 
 resource "azurerm_role_assignment" "tfstate_role_assignment" {
-  scope               = azurerm_storage_container.tfstate.id
-  role_definition_name  = "Storage Blob Data Owner"
-  principal_id        = data.azurerm_client_config.current.object_id
+  scope                = azurerm_storage_container.tfstate.id
+  role_definition_name = "Storage Blob Data Owner"
+  principal_id         = data.azurerm_client_config.current.object_id
 }
 
 resource "azurerm_storage_account_network_rules" "tfstate_acl" {
-  count = var.tfstate_acl_enable ? 1 : 0
+  count              = var.tfstate_acl_enable ? 1 : 0
   storage_account_id = azurerm_storage_account.tfstate.id
   # ---- (Required) Specifies the default action of allow or deny when no other rules match. Valid options are Deny or Allow.
-  default_action     = var.tfstate_acl_default_action
+  default_action = var.tfstate_acl_default_action
   # ----  (Optional) List of public IP or IP ranges in CIDR Format. Only IPv4 addresses are allowed. Private IP address ranges (as defined in RFC 1918) are not allowed.
-  ip_rules           = var.tfstate_acl_ip_rule
+  ip_rules = var.tfstate_acl_ip_rule
   # ---- (Optional) Specifies whether traffic is bypassed for Logging/Metrics/AzureServices. Valid options are any combination of Logging, Metrics, AzureServices, or None. Defaults to ["AzureServices"].
-  bypass             = var.tfstate_acl_bypass
+  bypass = var.tfstate_acl_bypass
 }
 
 # ---- Any resources that are added need to be added to the depends on array in the sanitize_state resource.  If resources are dependant, then only the sub-resources need to be added to the array.

--- a/main.tf
+++ b/main.tf
@@ -26,10 +26,12 @@ resource "random_string" "storage_account_name" {
 }
 
 locals {
-  environment_str = var.environment != null ? lower(var.environment) : ""
+  environment_str      = var.environment != null ? lower(var.environment) : ""
   storage_account_name = var.storage_account_name != null ? var.storage_account_name : (
-    substr("tfst${local.environment_str}${random_string.storage_account_name.result}", 0, 24)
+    substr("tfstate00${local.environment_str}${random_string.storage_account_name.result}", 0, 24)
   )
+  container_name       = var.container_name != null ? var.container_name : "terraform-state${local.environment_str != "" ? "-${local.environment_str}" : ""}"
+  tfstate_key          = var.tfstate_key != null ? var.tfstate_key : "terraform${local.environment_str != "" ? "-${local.environment_str}" : ""}.tfstate"
 }
 
 data "azurerm_client_config" "current" {
@@ -78,7 +80,7 @@ resource "azurerm_storage_account" "tfstate" {
 }
 
 resource "azurerm_storage_container" "tfstate" {
-  name                  = var.container_name
+  name                  = local.container_name
   storage_account_id    = azurerm_storage_account.tfstate.id
   container_access_type = "private"
 }
@@ -118,16 +120,22 @@ resource "null_resource" "sanitize_state" {
   }
 }
 
+data "azurerm_subscription" "current" {
+  subscription_id = var.subscription_id
+}
+
 locals {
   backend = <<BACKENDCONFIG
   terraform {
     backend "azurerm" {
-      use_cli              = true                                                       # Can also be set via `ARM_USE_CLI` environment variable.
-      use_azuread_auth     = true                                                       # Can also be set via `ARM_USE_AZUREAD` environment variable.
-      tenant_id            = "${data.azurerm_client_config.current.tenant_id}"          # Can also be set via `ARM_TENANT_ID` environment variable. Azure CLI will fallback to use the connected tenant ID if not supplied.
-      storage_account_name = "${azurerm_storage_account.tfstate.name}"                  # Can be passed via `-backend-config=`"storage_account_name=<storage account name>"` in the `init` command.
-      container_name       = "${azurerm_storage_container.tfstate.name}"                # Can be passed via `-backend-config=`"container_name=<container name>"` in the `init` command.
-      key                  = "<name key according to Azure blob naming rules>.tfstate"  # Can be passed via `-backend-config=`"key=<blob key name>"` in the `init` command.
+      use_cli              = true
+      use_azuread_auth     = true
+      subscription_id      = "${data.azurerm_subscription.current.subscription_id}" # ${data.azurerm_subscription.current.display_name}
+      tenant_id            = "${data.azurerm_client_config.current.tenant_id}"
+      storage_account_name = "${azurerm_storage_account.tfstate.name}"
+      container_name       = "${azurerm_storage_container.tfstate.name}"
+      key                  = "${local.tfstate_key}"
+    }
   }
   BACKENDCONFIG
 }


### PR DESCRIPTION
I took #20 and beefed it up a little bit:

- The storage account, storage container, and blob name (tfstate file) now consider the optional, new `environment` input.
- Added an optional input `tfstate_key`.
- Wanted to shorten but retained original tfstate key prefix `tfstate00` for better chance of smooth upgrade. It's also clearer what the file's intent is.
- Added `data` subscription lookup sugar to make generated backend config friendlier (provides subscription name in output comment).
- Fixed some previously undetected bugs in generated backend config and referenced output variable.
- Cleaned up generated backend config: I removed all the comments which are Terraform knowledge outside the scope of this module to educate the consumer.
- Very inelegant upgrade path for existing implementations. Not just breaking but destroying without intentional import, so I've added an update guide.

It is not entirely backward compatible, so I've added and linked an UPDATE.md to guide the consumer. It is a little overkill, but it's a good exercise and very thorough.

This is a pretty major change. It might be good to first consider the fate of #23 first.

Resolves #20 